### PR TITLE
speed up conversion by numpy-izing `turbomap`

### DIFF
--- a/convert_to_mcap.py
+++ b/convert_to_mcap.py
@@ -199,7 +199,7 @@ def turbomap(x):
     a = x.astype(np.uint8)
     x -= a  # compute "f" in place
     b = np.minimum(254, a)
-    np.add(b, 1, out=b)
+    b += 1
     color_a = TURBOMAP_DATA[a]
     color_b = TURBOMAP_DATA[b]
     color_b -= color_a


### PR DESCRIPTION
Total time for `scene-0061` on M1 Pro reduced from ~138s to ~98s.

Before:
![image](https://user-images.githubusercontent.com/14237/186531384-b2ccbb31-ee6a-481e-ae0f-cd87064c483f.png)

After:

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
...
     1318    0.172    0.000    0.263    0.000 convert_to_mcap.py:196(turbomap)
```
