### PR TITLE
Dockerfile: pin Shapely v1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update
 RUN apt-get install -y git python3-pip python3-tf2-ros ros-noetic-foxglove-msgs libgl1 libgeos-dev
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install numpy==1.19 nuscenes-devkit mcap 'mcap-protobuf-support>=0.0.8' foxglove-data-platform tqdm requests protobuf
+RUN pip3 install shapely==1.8.* numpy==1.19 nuscenes-devkit mcap 'mcap-protobuf-support>=0.0.8' foxglove-data-platform tqdm requests protobuf
 RUN pip3 install git+https://github.com/DanielPollithy/pypcd.git
 
 COPY . /work

--- a/convert_to_mcap.py
+++ b/convert_to_mcap.py
@@ -8,7 +8,7 @@ from typing import Dict, Tuple
 import numpy as np
 import rospy
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
-from mcap.mcap0.writer import Writer, CompressionType
+from mcap.writer import Writer, CompressionType
 from nuscenes.can_bus.can_bus_api import NuScenesCanBus
 from nuscenes.eval.common.utils import quaternion_yaw
 from nuscenes.map_expansion.map_api import NuScenesMap


### PR DESCRIPTION
Shapely 2.0 has been released, which breaks `nuscenes-devkit`.