### PR TITLE
upload: use synthetic device name

### DIFF
--- a/device_name.py
+++ b/device_name.py
@@ -1,0 +1,9 @@
+import hashlib
+from typing import Dict
+
+
+def make_device_name(metadata: Dict[str, str]) -> str:
+    """constructs a synthetic device name from vehicle name and location."""
+    vehicle = metadata["vehicle"]
+    location = metadata["location"]
+    return hashlib.sha256((vehicle + location).encode("utf8")).hexdigest()[:6]

--- a/upload_events.py
+++ b/upload_events.py
@@ -10,6 +10,7 @@ from mcap.mcap0.reader import make_reader
 from sensor_msgs.msg import Imu
 from foxglove.SceneUpdate_pb2 import SceneUpdate
 
+from device_name import make_device_name
 from event_helpers.annotators import Annotator
 from event_helpers.client_utils import get_all_events_for_device
 
@@ -58,12 +59,12 @@ def main():
                 (metadata for metadata in reader.iter_metadata() if metadata.name == "scene-info"),
                 None,
             )
+            device_name = make_device_name(scene_info.metadata)
             try:
-                vehicle = scene_info.metadata["vehicle"]
-                device_id = device_ids[vehicle]
+                device_id = device_ids[device_name]
             except KeyError:
                 print(
-                    f"device ID not found for vehicle '{vehicle}' - has this MCAP been uploaded?",
+                    f"device ID not found for '{device_name}' - has this MCAP been uploaded?",
                     file=sys.stderr,
                 )
                 return 1

--- a/upload_mcap.py
+++ b/upload_mcap.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from foxglove_data_platform.client import Client
 from mcap.mcap0.reader import make_reader
+from device_name import make_device_name
 
 from tqdm import tqdm
 
@@ -52,7 +53,7 @@ def main():
         with open(filepath, "rb") as f:
             reader = make_reader(f)
             scene_info = next(metadata for metadata in reader.iter_metadata() if metadata.name == "scene-info")
-            device_name = scene_info.metadata["vehicle"]
+            device_name = make_device_name(scene_info.metadata)
             device_id = device_ids.get(device_name)
             if device_id is None:
                 client.create_device(name=device_name)


### PR DESCRIPTION
This expands the set of devices produced, giving us more devices to work with when demoing Data Platform.